### PR TITLE
Enhancement: Configurable Title Color for Markdown Popup Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,23 @@ You can customize the following settings:
 
 If you do not configure Markdown Headers or leave certain settings unconfigured, it will use its default settings for those settings.
 
-**NOTE**: This will start Markdown Headers with it's default configuration (refer to the header above).
+The color of both the border and the title can be changed independently. This can be done by changing the highlight color of the element, either manually or by configuring it in the configuration file, as shown below.
+
+1.  Using the configuration file to change the highlight colors:
+
+```lua
+-- Change the border and title highlight color to '#61afef'.
+do
+    vim.cmd [[
+        highlight! MarkdownHeadersTitle guifg=#61afef
+        highlight! MarkdownHeadersBorder guifg=#61afef
+    ]]
+end
+```
+
+2. Manually change the highlight colors:
+    - Title: `highlight MarkdownHeadersTitle guifg=#61afef`
+    - Border: `highlight MarkdownHeadersBorder guifg=#61afef`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ You can customize the following settings:
 
 If you do not configure Markdown Headers or leave certain settings unconfigured, it will use its default settings for those settings.
 
-The color of both the border and the title can be changed independently. This can be done by changing the highlight color of the element, either manually or by configuring it in the configuration file, as shown below.
+The text, border, and title colors can be independently customized by adjusting their highlight colors. This can be achieved through either manual changes or configuration file settings, as demonstrated below:
 
 1.  Using the configuration file to change the highlight colors:
 
@@ -144,6 +144,9 @@ end
 2. Manually change the highlight colors:
     - Title: `highlight MarkdownHeadersTitle guifg=#61afef`
     - Border: `highlight MarkdownHeadersBorder guifg=#61afef`
+    - Text: `highlight MarkdownHeadersWindow guifg=#61afef`
+
+This enables users to have fine-grained control over the visual appearance of the text, border, and title according to their preferences/needs.
 
 ## Usage
 

--- a/lua/md-headers/init.lua
+++ b/lua/md-headers/init.lua
@@ -90,6 +90,7 @@ local function open_header_window(closest_header)
         title = "Markdown Headers",
         highlight = "MarkdownHeadersWindow",
         titlehighlight = 'MarkdownHeadersTitle',
+        borderhighlight = 'MarkdownHeadersBorder',
         line = math.floor(((vim.o.lines - height) / 2) - 1),
         col = math.floor((vim.o.columns - width) / 2),
         minwidth = width,

--- a/lua/md-headers/init.lua
+++ b/lua/md-headers/init.lua
@@ -89,6 +89,7 @@ local function open_header_window(closest_header)
     local _, window = popup.create(buffer, {
         title = "Markdown Headers",
         highlight = "MarkdownHeadersWindow",
+        titlehighlight = 'MarkdownHeadersTitle',
         line = math.floor(((vim.o.lines - height) / 2) - 1),
         col = math.floor((vim.o.columns - width) / 2),
         minwidth = width,


### PR DESCRIPTION
**Description:**

Addresses issue #2: Customizable Colors for Markdown Popup Titles.

**Changes Made:**

1. Added a configurable option to set the color of the title in Markdown popup windows.
2. Implemented the highlight group `MarkdownHeadersTitle`, which will allow users to change the color of the title interactively. Example: `highlight MarkdownHeadersTitle guifg=<color>`.
2. Implemented the highlight group `MarkdownHeadersBorder`, which will allow users to change the color of the border interactively. Example: `highlight MarkdownHeadersBorder guifg=<color>`.


**TODO:**
- [X] Implement a way to change the color of the title. ([ac1cd9e](https://github.com/AntonVanAssche/md-headers.nvim/pull/3/commits/ac1cd9efd1d9940278da8abf4b188ad2173edca6))
- [X] Implement a way to change the color of the border. ([a2975fa](https://github.com/AntonVanAssche/md-headers.nvim/pull/3/commits/a2975fab63bf794698765f149600aad88e193ebd))
- [X] Update documentation about plugin customization and configuration. ([e931295](https://github.com/AntonVanAssche/md-headers.nvim/pull/3/commits/e931295a54c8308ab506bc14a1cc2132a9ec3afc) and [b12688f](https://github.com/AntonVanAssche/md-headers.nvim/pull/3/commits/b12688f1da63ac8ea18205fe6fb2ae412a5c5731))

**Screenshots:**

| Title | Border |
| :-: | :-: |
| ![Screenshot from 2023-10-21 20-04-02](https://github.com/AntonVanAssche/md-headers.nvim/assets/61730941/11dde3e0-a021-4668-800f-bfa89d50e38b) | ![Screenshot from 2023-10-21 20-25-23](https://github.com/AntonVanAssche/md-headers.nvim/assets/61730941/28bde673-f07b-4952-a95d-893df13f40b1) |
