### PR TITLE
Enhancement: Add RMarkdown support

### DIFF
--- a/plugin/md-headers.lua
+++ b/plugin/md-headers.lua
@@ -9,7 +9,7 @@ vim .api.nvim_create_autocmd(
     'BufWinEnter', {
     pattern = {
         '*.md',
-        '*.rmd'
+        '*.[rR]md'
     },
     callback = function()
         vim.api.nvim_create_user_command('MarkdownHeaders', function()
@@ -22,7 +22,7 @@ vim .api.nvim_create_autocmd(
     'BufWinEnter', {
     pattern = {
         '*.md',
-        '*.rmd'
+        '*.[rR]md'
     },
     callback = function()
         vim.api.nvim_create_user_command('MarkdownHeadersClosest', function()

--- a/plugin/md-headers.lua
+++ b/plugin/md-headers.lua
@@ -7,7 +7,10 @@ end
 -- containing a Markdown file.
 vim .api.nvim_create_autocmd(
     'BufWinEnter', {
-    pattern = '*.md',
+    pattern = {
+        '*.md',
+        '*.rmd'
+    },
     callback = function()
         vim.api.nvim_create_user_command('MarkdownHeaders', function()
             require('md-headers').markdown_headers(false)
@@ -17,7 +20,10 @@ vim .api.nvim_create_autocmd(
 
 vim .api.nvim_create_autocmd(
     'BufWinEnter', {
-    pattern = '*.md',
+    pattern = {
+        '*.md',
+        '*.rmd'
+    },
     callback = function()
         vim.api.nvim_create_user_command('MarkdownHeadersClosest', function()
             require('md-headers').markdown_headers(true)


### PR DESCRIPTION
**Description:**

Addresses issue #7: Is there a way to make the plugin work with .rmd files for RMarkdown?

**Changes Made:**

Modified the md-headers.lua file to include the `.rmd` and `.Rmd` file extension in the pattern variable.

**TODO:**

- [X] Add support for RMarkdown files using both the `.rmd` and `.Rmd` file extension.

**Screenshots:**

![image](https://github.com/AntonVanAssche/md-headers.nvim/assets/61730941/9d28c56f-d6e7-4773-86ab-723034938706)