### PR TITLE
 Enhancement: Add Quarto support

### DIFF
--- a/plugin/md-headers.lua
+++ b/plugin/md-headers.lua
@@ -9,7 +9,8 @@ vim .api.nvim_create_autocmd(
     'BufWinEnter', {
     pattern = {
         '*.md',
-        '*.[rR]md'
+        '*.[rR]md',
+        '*.[qQ]md'
     },
     callback = function()
         vim.api.nvim_create_user_command('MarkdownHeaders', function()
@@ -22,7 +23,8 @@ vim .api.nvim_create_autocmd(
     'BufWinEnter', {
     pattern = {
         '*.md',
-        '*.[rR]md'
+        '*.[rR]md',
+        '*.[qQ]md'
     },
     callback = function()
         vim.api.nvim_create_user_command('MarkdownHeadersClosest', function()


### PR DESCRIPTION
**Description:**

Addresses issue #9:  Add Quarto support.

**Changes Made:**

This commit modifies the autocmd configuration in `md-headers.lua` to include the `*.qmd` and `*.Qmd` patterns. This addition allows the plugin to work seamlessly with Quarto files, extending its compatibility beyond Markdown and RMarkdown files.

**TODO:**

- [X] Add support for Quarto files using both the `.qmd` and `.Qmd` file extension.

**Screenshots:**

![image](https://github.com/AntonVanAssche/md-headers.nvim/assets/61730941/cbc570ee-8206-499b-8c6d-2aee1c3f7415)
