### PR TITLE
Enhancement: Introduce Customizable Auto-Close Behavior for Popup Window Selections

### DIFF
--- a/.github/WIKI/Configuration.md
+++ b/.github/WIKI/Configuration.md
@@ -1,5 +1,3 @@
-
-
 This page provides instructions on how to configure the Markdown Headers plugin according to your preferences. You can customize various settings to tailor the plugin to your specific needs.
 
 # 1. Initialization in init.vim
@@ -26,9 +24,9 @@ end
 md_headers.setup {
     width = 60,
     height = 10,
-    borderchars = { '─', '│', '─', '│', '╭', '╮', '╯', '╰'}
+    borderchars = { '─', '│', '─', '│', '╭', '╮', '╯', '╰'},
+    popup_auto_close = true
 }
-
 -- Shorten function name.
 local keymap = vim.keymap.set
 -- Silent keymap option.
@@ -43,12 +41,33 @@ keymap('n', '<leader>mdhc', ':MarkdownHeadersClosest<CR>', opts)
 
 You can customize the following settings:
 
--   `width`: The width of the Markdown Headers popup window.
-    -   Example: Setting the width to '100' makes the popup window 100 columns wide.
--   `height`: The height of the Markdown Headers popup window.
-    -   Example: Setting the height to '30' results in a popup window that is 30 lines high.
--   `borderchars`: The characters used to draw the border around the popup window.
-    -   Example: Setting borderchars to `{ '', '', '', '', '', '', '', '' }` results in a borderless popup window.
+## 3.1 Width
+
+You can customize the width of the Markdown Headers popup window using the `width` setting.
+
+-   **Format:** Numeric
+-   **Example:** Setting the width to '100' makes the popup window 100 columns wide.
+
+## 3.2 Height
+
+Adjust the height of the Markdown Headers popup window with the `height` setting.
+
+-   **Format:** Numeric
+-   **Example:** Setting the height to '30' results in a popup window that is 30 lines high.
+
+## 3.3 Border Characters
+
+Customize the characters used to draw the border around the popup window using the `borderchars` setting.
+
+-   **Format:** Array of eight strings
+-   **Example:** Setting borderchars to ``{ '', '', '', '', '', '', '', '' }`` results in a borderless popup window.
+
+## 3.4 Popup Auto-Close
+
+Specify whether the popup window should automatically close after selecting a heading using the `popup_auto_close` setting.
+
+-   **Format:** Boolean (true or false)
+-   **Example:** Setting `popup_auto_close` to false will **NOT** automatically close the popup window after selecting a heading.
 
 # 4. Default Settings
 

--- a/.github/WIKI/Installation.md
+++ b/.github/WIKI/Installation.md
@@ -50,4 +50,4 @@ return {
 
 # 3. Lazy Loading
 
-t's not recommended to lazy load Markdown Headers. The plugin isn't resource-expensive, performing minimal validation and configuration setting. There's no performance benefit from lazy loading.
+It's not recommended to lazy load Markdown Headers. The plugin isn't resource-expensive, performing minimal validation and configuration setting. There's no performance benefit from lazy loading.

--- a/.github/WIKI/Usage.md
+++ b/.github/WIKI/Usage.md
@@ -19,7 +19,7 @@ Navigate through the headings using the following keybindings:
 -   Press `Enter` on a heading to move the cursor to the corresponding heading in the main window.
 -   Press `Escape` or `q` to close the floating window.
 
-The window will also close automatically once you've selected a heading, optimizing your workflow.
+The popup window is designed to automatically close upon selecting a heading, streamlining your workflow. However, this behavior changes when the `popup_auto_close` option is configured as `false` in your settings file, preventing automatic closure. Refer to the [configuration](https://github.com/AntonVanAssche/md-headers.nvim/wiki/Configuration) page for additional details on this setting.
 
 # 3. Keybinding Recommendation
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@
         <a href="https://github.com/AntonVanAssche/md-headers.nvim/network/members">
             <img src="https://img.shields.io/github/forks/AntonVanAssche/md-headers.nvim.svg?style=for-the-badge">
         </a>
-        <a href="https://github.com/github_username/AntonVanAssche/md-headers.nvim">
+        <a href="https://github.com/ntonVanAssche/md-headers.nvim">
             <img src="https://img.shields.io/github/stars/AntonVanAssche/md-headers.nvim.svg?style=for-the-badge">
         </a>
-        <a href="https://github.com/github_username/AntonVanAssche/md-headers.nvim">
+        <a href="https://github.com/AntonVanAssche/md-headers.nvim">
             <img src="https://img.shields.io/github/issues/AntonVanAssche/md-headers.nvim.svg?style=for-the-badge">
         </a>
         <a href="https://github.com/AntonVanAssche/md-headers.nvim/blob/master/LICENSE">

--- a/lua/md-headers/init.lua
+++ b/lua/md-headers/init.lua
@@ -104,24 +104,14 @@ end
 
 -- Gets the closest header above the current cursor position.
 -- Returns the corresponding line inside the popup window.
--- @param buffer The buffer to search for headers.
 -- @return popup_window_line: number
-local function get_closest_header_above(buffer)
+local function get_closest_header_above()
     local line = vim.api.nvim_win_get_cursor(0)[1]
-
     local popup_window_line = 0
-    local root = get_root(buffer)
 
-    for id, node in md_query:iter_captures(root, buffer, 0, -1) do
-        local name = md_query.captures[id]
-
-        if name == "md_heading" then
-            local range = { node:range() }
-            local distance = line - range[1]
-
-            if distance > 0 then
-                popup_window_line = popup_window_line + 1
-            end
+    for _, header in ipairs(headers) do
+        if header.line < line then
+            popup_window_line = popup_window_line + 1
         end
     end
 


### PR DESCRIPTION
**Description:**

Addresses issue #13:  Request: Customizable Auto-Close Behavior for Popup Window Selections.

**Changes Made:**

1.  Implemented the `popup_auto_close` setting to allow users to customize the auto-close behavior of the popup window after selecting a heading.
2.  Updated the `get_closest_header_above()` function for improved efficiency, and fix a bug related to HTML headings.
3.  Updated the `Configuration.md` documentation to include details about the `popup_auto_close` setting.
4.  Clarified the behavior of the popup window in the `Usage.md` documentation, especially regarding auto-closure and the impact of the `popup_auto_close` configuration.

**TODO:**

- [X] Implement the `popup_auto_close` setting.
- [X] Optimize get_closest_header_above() function.
- [X] Update Configuration.md documentation.
- [X] Clarify Popup Auto-Close Behavior in Usage.md.

**Preview:**

![md-headers-auto-close-setting](https://github.com/AntonVanAssche/md-headers.nvim/assets/61730941/6c6ce2b0-a663-402e-ab86-45e674724605)