### PR TITLE
Update Installation.md

### DIFF
--- a/.github/WIKI/Installation.md
+++ b/.github/WIKI/Installation.md
@@ -41,6 +41,7 @@ return {
     lazy = false,
     dependencies = {
         'nvim-lua/plenary.nvim',
+        'nvim-treesitter/nvim-treesitter',
     },
     config = function()
         require('md-headers').setup {}


### PR DESCRIPTION
if using Lazy for installing pluggins, then md-headers plugin can load prior to treesitter. this causes an error where the markdown language parser cannot be found when running the require function for setup for md-headers. By adding treesittter as a dependency, then md-headers will only load correctly assuming treesitter's markdown language parser is installed.