### PR TITLE
[workflow] Use default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ name: Lint
 on:
   push:
     branches:
-      - master
+      - '*'
   pull_request:
     branches:
       - master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,5 +18,5 @@ jobs:
       - uses: JohnnyMorganz/stylua-action@v3
         with:
           version: latest
-          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           args: --color always --check lua

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ name: Test
 on:
   push:
     branches:
-      - master
+      - '*'
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Ensures that the action works for PRs of non-project members.