### PR TITLE
Add config option for customizing header depth icons

### DIFF
--- a/doc/md-headers.txt
+++ b/doc/md-headers.txt
@@ -100,6 +100,9 @@ Default configuration:
     borderchars = {                  -- Characters used for the window border
       "─", "│", "─", "│", "╭", "╮", "╯", "╰"
     },
+    headerchars = {                  -- Characters used for the header icons
+      "󰲡 ", "󰲣 ", "󰲥 ", "󰲧 ", "󰲩 ", "󰲫 "
+    },
     popup_auto_close = true,         -- Automatically close popup after use
     win_options = {                  -- Window options for the floating window
       number = false,                -- Disable line numbers
@@ -125,6 +128,7 @@ configuration:
     width = 80,
     height = 15,
     borderchars = { "-", "|", "-", "|", "+", "+", "+", "+" },
+    headerchars = { "(1)", "(2)", "(3)", "(4)", "(5)", "(6)" },
     popup_auto_close = false,
     win_options = {
       number = true,
@@ -140,8 +144,8 @@ configuration:
 <
 
 This setup example customizes the floating window size, changes the border
-characters, disables automatic popup closing, and applies specific colors to
-highlight groups.
+characters, changes the header depth icons, disables automatic popup closing, 
+and applies specific colors to highlight groups.
 
                                  *md-headers-configuration-recommended-keymaps*
 CONFIGURATION RECOMMENDED KEYMAPS

--- a/lua/md-headers/config.lua
+++ b/lua/md-headers/config.lua
@@ -13,6 +13,7 @@ M.config = {
   width = 60,
   height = 10,
   borderchars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
+  headerchars = { "󰲡 ", "󰲣 ", "󰲥 ", "󰲧 ", "󰲩 ", "󰲫 " },
   popup_auto_close = true,
   win_options = {
     number = false,

--- a/lua/md-headers/health.lua
+++ b/lua/md-headers/health.lua
@@ -71,6 +71,21 @@ local _check_borderchars_chars = function()
   return true
 end
 
+local _check_headerchars_len = function()
+  return type(config.headerchars) == "table" and #config.headerchars == 6
+end
+
+local _check_headerchars_chars = function()
+  local headerchars = config.headerchars
+  for _, char in ipairs(headerchars) do
+    if type(char) ~= "string" then
+      return false
+    end
+  end
+
+  return true
+end
+
 local _check_popup_auto_close = function()
   return type(config.popup_auto_close) == "boolean"
 end
@@ -141,6 +156,18 @@ M.check = function()
       "Borderchars elements are not strings with length 0 or 1, got: "
         .. vim.inspect(config.borderchars)
     )
+  end
+
+  if _check_headerchars_len() then
+    ok("Headerchars is a table with 6 elements")
+  else
+    error("Headerchars is not a table with 6 elements, got " .. #config.headerchars)
+  end
+
+  if _check_headerchars_chars() then
+    ok("Headerchars elements are strings")
+  else
+    warn("Headerchars elements are not strings, got: " .. vim.inspect(config.headerchars))
   end
 
   if _check_popup_auto_close() then

--- a/lua/md-headers/health.lua
+++ b/lua/md-headers/health.lua
@@ -1,4 +1,4 @@
-local ts_config = require("nvim-treesitter.configs")
+local ts_config = require("nvim-treesitter.config")
 local config = require("md-headers.config").config
 
 local M = {}
@@ -23,7 +23,7 @@ end
 
 local _check_ts_parser_is_installed = function(lang)
   local matched_parsers = vim.api.nvim_get_runtime_file("parser/" .. lang .. ".so", true) or {}
-  local install_dir = ts_config.get_parser_install_dir()
+  local install_dir = ts_config.get_install_dir()
   if not install_dir then
     return false
   end

--- a/lua/md-headers/ui.lua
+++ b/lua/md-headers/ui.lua
@@ -4,8 +4,7 @@ local popup = require("plenary.popup")
 local M = {}
 
 local _get_icon = function(depth)
-  local icons = { "󰲡", "󰲣", "󰲥", "󰲧", "󰲩", "󰲫" }
-  return icons[depth] or ""
+  return config.config.headerchars[depth] or ""
 end
 
 local _set_window_options = function(win_id)
@@ -60,7 +59,7 @@ local _set_window_contents = function(bufnr, headings)
   for _, heading in ipairs(headings) do
     table.insert(
       contents,
-      string.rep("  ", heading.depth - 1) .. _get_icon(heading.depth) .. " " .. heading.text
+      string.rep("  ", heading.depth - 1) .. _get_icon(heading.depth) .. heading.text
     )
   end
 


### PR DESCRIPTION
This adds a `headerchars` config option which allows the user to customize the depth icons used for headers in the popup window (#34). The config value is just a table with six elements, one for each header level.

One note is while the old implementation hard coded an additional space between the icon character and the header (to accommodate the double-width icon characters), the new implementation integrates that space character into the default config values, allowing more flexibility if someone doesn't want a space between their icon and the header text.

Along the way I fixed #36, since that was required to test the health checks for the new config option.