### PR TITLE
Add header indentation and popup scrolloff config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,13 @@ Default config:
   height = 10,
   borderchars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
   headerchars = { "󰲡 ", "󰲣 ", "󰲥 ", "󰲧 ", "󰲩 ", "󰲫 " },
+  indent = 2,
   popup_auto_close = true,
   win_options = {
     number = false,
     relativenumber = false,
     cursorline = true,
+    scrolloff = 0,
   },
   highlight_groups = {
     title = { fg = nil, bg = nil },

--- a/doc/md-headers.txt
+++ b/doc/md-headers.txt
@@ -71,8 +71,8 @@ CONFIGURATION                                       *md-headers-configuration*
 ------------------------------------------------------------------------------
 CONFIGURATION SETUP                           *md-headers-configuration-setup*
 
-To override the default configuration: >
-
+To override the default configuration: 
+>lua
   require('md-headers').setup({
     width = 80,
     height = 15,
@@ -84,7 +84,8 @@ To override the default configuration: >
       border = { fg = "#00FF00" },
       text = { fg = "#0000FF" },
     },
-  }) <
+  })
+<
 
 This setup example customizes the floating window size, changes the border
 characters, changes the header depth icons, disables automatic popup closing,
@@ -111,7 +112,7 @@ height                                                          (number)
 borderchars                                                     (table)
     Characters used for the window border. ~
     Default:
->
+>lua
       { "─", "│", "─", "│", "╭", "╮", "╯", "╰" }
 <
 
@@ -119,7 +120,7 @@ borderchars                                                     (table)
 headerchars                                                      (table)
     Icons used for heading levels. ~
     Default:
->
+>lua
       { "󰲡 ", "󰲣 ", "󰲥 ", "󰲧 ", "󰲩 ", "󰲫 " }
 <
 
@@ -137,7 +138,7 @@ popup_auto_close                                               (boolean)
 win_options                                                    (table)
     Window options applied to the floating window. ~
     Default:
->
+>lua
       {
         number = false,
         relativenumber = false,
@@ -150,7 +151,7 @@ win_options                                                    (table)
 highlight_groups                                               (table)
     Highlight groups used by the popup. ~
     Default:
->
+>lua
       {
         title  = { fg = nil, bg = nil },
         border = { fg = nil, bg = nil },

--- a/doc/md-headers.txt
+++ b/doc/md-headers.txt
@@ -142,6 +142,7 @@ win_options                                                    (table)
         number = false,
         relativenumber = false,
         cursorline = true,
+        scrolloff = 0,
       }
 <
 

--- a/doc/md-headers.txt
+++ b/doc/md-headers.txt
@@ -123,6 +123,11 @@ headerchars                                                      (table)
       { "󰲡 ", "󰲣 ", "󰲥 ", "󰲧 ", "󰲩 ", "󰲫 " }
 <
 
+                                                       *md-headers-indent*
+indent                                                          (number)
+    Indent width per heading level. ~
+    Default: `2`
+
                                              *md-headers-popup-auto-close*
 popup_auto_close                                               (boolean)
     Automatically close the popup after selection. ~

--- a/lua/md-headers/health.lua
+++ b/lua/md-headers/health.lua
@@ -56,6 +56,10 @@ local check_height = function()
   return type(config.height) == "number" and config.height > 0
 end
 
+local check_indent = function()
+  return type(config.indent) == "number" and config.indent >= 0
+end
+
 local check_borderchars_len = function()
   return type(config.borderchars) == "table" and #config.borderchars == 8
 end
@@ -141,6 +145,12 @@ M.check = function()
     ok("Height is a positive number")
   else
     error("Height is not a positive number, got " .. vim.inspect(config.height))
+  end
+
+  if check_indent() then
+    ok("Indent is a non-negative number")
+  else
+    error("Indent is not a non-negative number, got " .. vim.inspect(config.height))
   end
 
   if check_borderchars_len() then

--- a/lua/md-headers/model/config.lua
+++ b/lua/md-headers/model/config.lua
@@ -5,6 +5,7 @@ M.defaults = {
   height = 10,
   borderchars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
   headerchars = { "󰲡 ", "󰲣 ", "󰲥 ", "󰲧 ", "󰲩 ", "󰲫 " },
+  indent = 2,
   popup_auto_close = true,
   win_options = {
     number = false,

--- a/lua/md-headers/model/config.lua
+++ b/lua/md-headers/model/config.lua
@@ -11,6 +11,7 @@ M.defaults = {
     number = false,
     relativenumber = true,
     cursorline = true,
+    scrolloff = 0,
   },
   highlight_groups = {
     title = {

--- a/lua/md-headers/ui/window.lua
+++ b/lua/md-headers/ui/window.lua
@@ -18,6 +18,7 @@ local function set_window_options(win_id)
   vim.api.nvim_set_option_value("number", opts.number, { win = win_id })
   vim.api.nvim_set_option_value("relativenumber", opts.relativenumber, { win = win_id })
   vim.api.nvim_set_option_value("cursorline", opts.cursorline, { win = win_id })
+  vim.api.nvim_set_option_value("scrolloff", opts.scrolloff, { win = win_id })
 end
 
 local function set_buffer_keymaps(bufnr)

--- a/lua/md-headers/ui/window.lua
+++ b/lua/md-headers/ui/window.lua
@@ -5,6 +5,10 @@ local utils = require("md-headers.model.utils")
 
 local M = {}
 
+local function get_indent(depth)
+  return string.rep(" ", config.values.indent * (depth - 1))
+end
+
 local function get_icon(depth)
   return config.values.headerchars[depth] or ""
 end
@@ -58,7 +62,7 @@ end
 local function set_window_contents(bufnr, headings)
   local lines = {}
   for _, h in ipairs(headings) do
-    table.insert(lines, string.rep("  ", h.depth - 1) .. get_icon(h.depth) .. h.text)
+    table.insert(lines, get_indent(h.depth) .. get_icon(h.depth) .. h.text)
   end
 
   vim.api.nvim_buf_set_lines(bufnr, 0, #lines, false, lines)


### PR DESCRIPTION
This adds two config options. `indent`, which sets the indentation depth per header level in the popup, and `win_options.scrolloff`, to set the popup window's `scrolloff`