### PR TITLE
Add per-depth header highlighting and refactor highlight group configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Default config:
     title = { fg = "NONE", bg = "NONE" },
     border = { fg = "NONE", bg = "NONE" },
     text = { fg = "NONE", bg = "NONE" },
+    headers = {},
   },
 }
 ```

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ Default config:
     cursorline = true,
   },
   highlight_groups = {
-    title = { fg = nil, bg = nil },
-    border = { fg = nil, bg = nil },
-    text = { fg = nil, bg = nil },
+    title = { fg = "NONE", bg = "NONE" },
+    border = { fg = "NONE", bg = "NONE" },
+    text = { fg = "NONE", bg = "NONE" },
   },
 }
 ```

--- a/doc/md-headers.txt
+++ b/doc/md-headers.txt
@@ -71,8 +71,8 @@ CONFIGURATION                                       *md-headers-configuration*
 ------------------------------------------------------------------------------
 CONFIGURATION SETUP                           *md-headers-configuration-setup*
 
-To override the default configuration: >
-
+To override the default configuration: 
+>lua
   require('md-headers').setup({
     width = 80,
     height = 15,
@@ -84,7 +84,8 @@ To override the default configuration: >
       border = { fg = "#00FF00" },
       text = { fg = "#0000FF" },
     },
-  }) <
+  })
+<
 
 This setup example customizes the floating window size, changes the border
 characters, changes the header depth icons, disables automatic popup closing,
@@ -111,7 +112,7 @@ height                                                          (number)
 borderchars                                                     (table)
     Characters used for the window border. ~
     Default:
->
+>lua
       { "─", "│", "─", "│", "╭", "╮", "╯", "╰" }
 <
 
@@ -119,7 +120,7 @@ borderchars                                                     (table)
 headerchars                                                      (table)
     Icons used for heading levels. ~
     Default:
->
+>lua
       { "󰲡 ", "󰲣 ", "󰲥 ", "󰲧 ", "󰲩 ", "󰲫 " }
 <
 
@@ -137,7 +138,7 @@ popup_auto_close                                               (boolean)
 win_options                                                    (table)
     Window options applied to the floating window. ~
     Default:
->
+>lua
       {
         number = false,
         relativenumber = false,
@@ -150,7 +151,7 @@ win_options                                                    (table)
 highlight_groups                                               (table)
     Highlight groups used by the popup. ~
     Default:
->
+>lua
       {
         title  = { fg = nil, bg = nil },
         border = { fg = nil, bg = nil },

--- a/doc/md-headers.txt
+++ b/doc/md-headers.txt
@@ -142,6 +142,7 @@ win_options                                                    (table)
         number = false,
         relativenumber = false,
         cursorline = true,
+        scrolloff = 0,
       }
 <
 

--- a/doc/md-headers.txt
+++ b/doc/md-headers.txt
@@ -83,6 +83,14 @@ To override the default configuration:
       title = { fg = "#FF0000" },
       border = { fg = "#00FF00" },
       text = { fg = "#0000FF" },
+      headers = {
+        "SomeH1Group",
+        "SomeH2Group",
+        "SomeH3Group",
+        "SomeH4Group",
+        "SomeH5Group",
+        "SomeH6Group",
+      }
     },
   })
 <
@@ -153,11 +161,15 @@ highlight_groups                                               (table)
     Default:
 >lua
       {
-        title  = { fg = nil, bg = nil },
-        border = { fg = nil, bg = nil },
-        text   = { fg = nil, bg = nil },
+        title   = { fg = "NONE", bg = "NONE" },
+        border  = { fg = "NONE", bg = "NONE" },
+        text    = { fg = "NONE", bg = "NONE" },
+        headers = {}, -- optional table with six values
       }
 <
+    Values in this table may be either a string, denoting an existing
+    highlight group name, or a highlight definition map as defined in
+    |nvim_set_hl()|.
 
 ------------------------------------------------------------------------------
                                 *md-headers-configuration-recommended-keymaps*

--- a/doc/md-headers.txt
+++ b/doc/md-headers.txt
@@ -123,6 +123,11 @@ headerchars                                                      (table)
       { "󰲡 ", "󰲣 ", "󰲥 ", "󰲧 ", "󰲩 ", "󰲫 " }
 <
 
+                                                       *md-headers-indent*
+indent                                                          (number)
+    Indent width per heading level. ~
+    Default: `2`
+
                                              *md-headers-popup-auto-close*
 popup_auto_close                                               (boolean)
     Automatically close the popup after selection. ~

--- a/lua/md-headers/health.lua
+++ b/lua/md-headers/health.lua
@@ -56,6 +56,10 @@ local check_height = function()
   return type(config.height) == "number" and config.height > 0
 end
 
+local check_indent = function()
+  return type(config.indent) == "number" and config.indent >= 0
+end
+
 local check_borderchars_len = function()
   return type(config.borderchars) == "table" and #config.borderchars == 8
 end
@@ -141,6 +145,12 @@ M.check = function()
     ok("Height is a positive number")
   else
     error("Height is not a positive number, got " .. vim.inspect(config.height))
+  end
+
+  if check_indent() then
+    ok("Indent is a non-negative number")
+  else
+    error("Indent is not a non-negative number, got " .. vim.inspect(config.height))
   end
 
   if check_borderchars_len() then

--- a/lua/md-headers/health.lua
+++ b/lua/md-headers/health.lua
@@ -39,10 +39,6 @@ local check_ts_parser_is_installed = function(lang)
   return false
 end
 
-local is_hex_color = function(color)
-  return type(color) == "string" and color:match("^#%x%x%x%x%x%x$") ~= nil
-end
-
 local get_utf8_len = function(str)
   local _, count = string.gsub(str, "[%z\1-\127\194-\244][\128-\191]*", "")
   return count
@@ -94,24 +90,70 @@ local check_popup_auto_close = function()
   return type(config.popup_auto_close) == "boolean"
 end
 
+local function check_highlight_error(value)
+  local success, error_message = pcall(function()
+    vim.api.nvim_set_hl(0, "MarkdownHeadersHealthCheck", value)
+  end)
+  if success then
+    return nil
+  end
+
+  local stripped_message = string.match(error_message, "health%.lua:%d+:%s*(.*)")
+  return stripped_message or error_message
+end
+
 local check_highlight_groups = function()
   if type(config.highlight_groups) ~= "table" then
-    return false
+    error("Highlight groups are not a table, got " .. vim.inspect(config.highlight_groups))
+    return
   end
 
-  local valid_highlight_keys = { "title", "border", "text" }
-  for _, key in ipairs(valid_highlight_keys) do
-    local group = config.highlight_groups[key]
-    if
-      group == nil
-      or (group.fg ~= nil and not is_hex_color(group.fg))
-      or (group.bg ~= nil and not is_hex_color(group.bg))
-    then
-      return false
+  if type(config.highlight_groups.headers) ~= "table" then
+    error(
+      "Highlight groups - `headers` is not a table, got "
+        .. vim.inspect(config.highlight_groups.headers)
+    )
+    return
+  end
+
+  -- { "text", config.highlight_groups.text },
+  local checks = {
+    { "title", config.highlight_groups.title },
+    { "border", config.highlight_groups.border },
+    { "text", config.highlight_groups.text },
+    { "headers[1]", config.highlight_groups.headers[1] },
+    { "headers[2]", config.highlight_groups.headers[2] },
+    { "headers[3]", config.highlight_groups.headers[3] },
+    { "headers[4]", config.highlight_groups.headers[4] },
+    { "headers[5]", config.highlight_groups.headers[5] },
+    { "headers[6]", config.highlight_groups.headers[6] },
+  }
+
+  for _, check in ipairs(checks) do
+    local check_name = check[1]
+    local check_value = check[2]
+    if type(check_value) == "string" then
+      ok("Highlight groups - `" .. check_name .. "` is valid")
+    elseif type(check_value) == "table" then
+      local error_message = check_highlight_error(check_value)
+      if error_message then
+        error(
+          "Highlight groups - `"
+            .. check_name
+            .. "` is invalid ("
+            .. error_message
+            .. "), got "
+            .. vim.inspect(check_value)
+        )
+      else
+        ok("Highlight groups - `" .. check_name .. "` is valid")
+      end
+    else
+      error(
+        "Highlight groups - `" .. check_name .. "` is invalid, got " .. vim.inspect(check_value)
+      )
     end
   end
-
-  return true
 end
 
 M.check = function()
@@ -186,11 +228,7 @@ M.check = function()
     error("Popup_auto_close is not a boolean, got " .. vim.inspect(config.popup_auto_close))
   end
 
-  if check_highlight_groups() then
-    ok("Highlight groups are valid")
-  else
-    error("Highlight groups are not valid, got: " .. vim.inspect(config.highlight_groups))
-  end
+  check_highlight_groups()
 end
 
 return M

--- a/lua/md-headers/model/config.lua
+++ b/lua/md-headers/model/config.lua
@@ -15,16 +15,16 @@ M.defaults = {
   },
   highlight_groups = {
     title = {
-      fg = nil,
-      bg = nil,
+      fg = "NONE",
+      bg = "NONE",
     },
     border = {
-      fg = nil,
-      bg = nil,
+      fg = "NONE",
+      bg = "NONE",
     },
     text = {
-      fg = nil,
-      bg = nil,
+      fg = "NONE",
+      bg = "NONE",
     },
     headers = {},
   },

--- a/lua/md-headers/model/config.lua
+++ b/lua/md-headers/model/config.lua
@@ -26,6 +26,7 @@ M.defaults = {
       fg = nil,
       bg = nil,
     },
+    headers = {},
   },
 }
 
@@ -37,28 +38,18 @@ M.supported_filetypes = {
   "rmd",
 }
 
-local function set_hl_colors()
-  local highlight_groups = M.values.highlight_groups
+M.resolved_highlights = {}
 
-  if highlight_groups.title.fg ~= nil or highlight_groups.title.bg ~= nil then
-    vim.api.nvim_set_hl(0, "MarkdownHeadersTitle", {
-      fg = highlight_groups.title.fg or "NONE",
-      bg = highlight_groups.title.bg or "NONE",
-    })
-  end
-
-  if highlight_groups.border.fg ~= nil or highlight_groups.border.bg ~= nil then
-    vim.api.nvim_set_hl(0, "MarkdownHeadersBorder", {
-      fg = highlight_groups.border.fg or "NONE",
-      bg = highlight_groups.border.bg or "NONE",
-    })
-  end
-
-  if highlight_groups.text.fg ~= nil or highlight_groups.text.bg ~= nil then
-    vim.api.nvim_set_hl(0, "MarkdownHeadersWindow", {
-      fg = highlight_groups.text.fg or "NONE",
-      bg = highlight_groups.text.bg or "NONE",
-    })
+local function resolve_highlight(default_name, config_value)
+  if type(config_value) == "string" then -- existing highlight group name
+    return config_value
+  elseif config_value == nil then -- fall back to non-existent highlight group
+    return ""
+  else
+    pcall(function()
+      vim.api.nvim_set_hl(0, default_name, config_value)
+    end)
+    return default_name
   end
 end
 
@@ -66,7 +57,20 @@ function M.setup(opts)
   opts = opts or {}
   M.values = vim.tbl_deep_extend("force", M.defaults, opts)
 
-  set_hl_colors()
+  local hl = M.values.highlight_groups
+  M.resolved_highlights = {
+    title = resolve_highlight("MarkdownHeadersTitle", hl.title),
+    border = resolve_highlight("MarkdownHeadersBorder", hl.border),
+    text = resolve_highlight("MarkdownHeadersWindow", hl.text),
+    headers = {
+      resolve_highlight("MarkdownHeadersH1", hl.headers[1]),
+      resolve_highlight("MarkdownHeadersH2", hl.headers[2]),
+      resolve_highlight("MarkdownHeadersH3", hl.headers[3]),
+      resolve_highlight("MarkdownHeadersH4", hl.headers[4]),
+      resolve_highlight("MarkdownHeadersH5", hl.headers[5]),
+      resolve_highlight("MarkdownHeadersH6", hl.headers[6]),
+    },
+  }
 end
 
 return M

--- a/lua/md-headers/model/config.lua
+++ b/lua/md-headers/model/config.lua
@@ -5,6 +5,7 @@ M.defaults = {
   height = 10,
   borderchars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
   headerchars = { "󰲡 ", "󰲣 ", "󰲥 ", "󰲧 ", "󰲩 ", "󰲫 " },
+  indent = 2,
   popup_auto_close = true,
   win_options = {
     number = false,

--- a/lua/md-headers/model/config.lua
+++ b/lua/md-headers/model/config.lua
@@ -11,6 +11,7 @@ M.defaults = {
     number = false,
     relativenumber = true,
     cursorline = true,
+    scrolloff = 0,
   },
   highlight_groups = {
     title = {

--- a/lua/md-headers/ui/window.lua
+++ b/lua/md-headers/ui/window.lua
@@ -18,6 +18,7 @@ local function set_window_options(win_id)
   vim.api.nvim_set_option_value("number", opts.number, { win = win_id })
   vim.api.nvim_set_option_value("relativenumber", opts.relativenumber, { win = win_id })
   vim.api.nvim_set_option_value("cursorline", opts.cursorline, { win = win_id })
+  vim.api.nvim_set_option_value("scrolloff", opts.scrolloff, { win = win_id })
 end
 
 local function set_buffer_keymaps(bufnr)

--- a/lua/md-headers/ui/window.lua
+++ b/lua/md-headers/ui/window.lua
@@ -4,6 +4,7 @@ local popup = require("plenary.popup")
 local utils = require("md-headers.model.utils")
 
 local M = {}
+local highlight_namespace = vim.api.nvim_create_namespace("md-headers")
 
 local function get_indent(depth)
   return string.rep(" ", config.values.indent * (depth - 1))
@@ -11,6 +12,10 @@ end
 
 local function get_icon(depth)
   return config.values.headerchars[depth] or ""
+end
+
+local function get_highlight(depth)
+  return config.resolved_highlights.headers[depth]
 end
 
 local function set_window_options(win_id)
@@ -42,9 +47,9 @@ end
 local function create_window(bufnr, width, height, borderchars)
   local _, win = popup.create(bufnr, {
     title = "Markdown Headers",
-    highlight = "MarkdownHeadersWindow",
-    titlehighlight = "MarkdownHeadersTitle",
-    borderhighlight = "MarkdownHeadersBorder",
+    highlight = config.resolved_highlights.text,
+    titlehighlight = config.resolved_highlights.title,
+    borderhighlight = config.resolved_highlights.border,
     line = math.floor((vim.o.lines - height) / 2 - 1),
     col = math.floor((vim.o.columns - width) / 2),
     minwidth = width,
@@ -68,6 +73,19 @@ local function set_window_contents(bufnr, headings)
 
   vim.api.nvim_buf_set_lines(bufnr, 0, #lines, false, lines)
   vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
+
+  for line, heading in ipairs(headings) do
+    local highlight = get_highlight(heading.depth)
+    if highlight then
+      vim.api.nvim_buf_set_extmark(
+        bufnr,
+        highlight_namespace,
+        line - 1,
+        #get_indent(heading.depth),
+        { end_col = #lines[line], hl_group = highlight }
+      )
+    end
+  end
 end
 
 local function open_window(headings, start_line)

--- a/lua/md-headers/ui/window.lua
+++ b/lua/md-headers/ui/window.lua
@@ -5,6 +5,10 @@ local utils = require("md-headers.model.utils")
 
 local M = {}
 
+local function get_indent(depth)
+  return string.rep(" ", config.values.indent * (depth - 1))
+end
+
 local function get_icon(depth)
   return config.values.headerchars[depth] or ""
 end
@@ -58,7 +62,7 @@ end
 local function set_window_contents(bufnr, headings)
   local lines = {}
   for _, h in ipairs(headings) do
-    table.insert(lines, string.rep("  ", h.depth - 1) .. get_icon(h.depth) .. h.text)
+    table.insert(lines, get_indent(h.depth) .. get_icon(h.depth) .. h.text)
   end
 
   vim.api.nvim_buf_set_lines(bufnr, 0, #lines, false, lines)


### PR DESCRIPTION
1. Adds a new key in `highlight_groups` for header highlights
2. Extends the interpretation of `highlight_groups` values:
    - Allows specifying an existing highlight group by name
    - Expands the table to support specifying the full `nvim_set_hl()` value

This new highlight group interpretation includes one minor breaking change, which is that setting `fg` or `bg` to `nil` will no longer default to `"NONE"`. The default value is now `{ fg = "NONE", bg = "NONE" }`, so the default value has not changed, however `{ fg = "#ff00ff" }` no longer translates to `{ fg = "#ff00ff", bg = "NONE" }`.
