### PR TITLE
Add option to customize header indents

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Default config:
   height = 10,
   borderchars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
   headerchars = { "󰲡 ", "󰲣 ", "󰲥 ", "󰲧 ", "󰲩 ", "󰲫 " },
+  indent = 2,
   popup_auto_close = true,
   win_options = {
     number = false,

--- a/doc/md-headers.txt
+++ b/doc/md-headers.txt
@@ -123,6 +123,11 @@ headerchars                                                      (table)
       { "󰲡 ", "󰲣 ", "󰲥 ", "󰲧 ", "󰲩 ", "󰲫 " }
 <
 
+                                                       *md-headers-indent*
+indent                                                          (number)
+    Indent width per heading level. ~
+    Default: `2`
+
                                              *md-headers-popup-auto-close*
 popup_auto_close                                               (boolean)
     Automatically close the popup after selection. ~

--- a/lua/md-headers/health.lua
+++ b/lua/md-headers/health.lua
@@ -56,6 +56,10 @@ local check_height = function()
   return type(config.height) == "number" and config.height > 0
 end
 
+local check_indent = function()
+  return type(config.indent) == "number" and config.indent >= 0
+end
+
 local check_borderchars_len = function()
   return type(config.borderchars) == "table" and #config.borderchars == 8
 end
@@ -141,6 +145,12 @@ M.check = function()
     ok("Height is a positive number")
   else
     error("Height is not a positive number, got " .. vim.inspect(config.height))
+  end
+
+  if check_indent() then
+    ok("Indent is a non-negative number")
+  else
+    error("Indent is not a non-negative number, got " .. vim.inspect(config.height))
   end
 
   if check_borderchars_len() then

--- a/lua/md-headers/health.lua
+++ b/lua/md-headers/health.lua
@@ -150,7 +150,7 @@ M.check = function()
   if check_indent() then
     ok("Indent is a non-negative number")
   else
-    error("Indent is not a non-negative number, got " .. vim.inspect(config.height))
+    error("Indent is not a non-negative number, got " .. vim.inspect(config.indent))
   end
 
   if check_borderchars_len() then

--- a/lua/md-headers/model/config.lua
+++ b/lua/md-headers/model/config.lua
@@ -5,6 +5,7 @@ M.defaults = {
   height = 10,
   borderchars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
   headerchars = { "󰲡 ", "󰲣 ", "󰲥 ", "󰲧 ", "󰲩 ", "󰲫 " },
+  indent = 2,
   popup_auto_close = true,
   win_options = {
     number = false,

--- a/lua/md-headers/ui/window.lua
+++ b/lua/md-headers/ui/window.lua
@@ -5,6 +5,10 @@ local utils = require("md-headers.model.utils")
 
 local M = {}
 
+local function get_indent(depth)
+  return string.rep(" ", config.values.indent * (depth - 1))
+end
+
 local function get_icon(depth)
   return config.values.headerchars[depth] or ""
 end
@@ -58,7 +62,7 @@ end
 local function set_window_contents(bufnr, headings)
   local lines = {}
   for _, h in ipairs(headings) do
-    table.insert(lines, string.rep("  ", h.depth - 1) .. get_icon(h.depth) .. h.text)
+    table.insert(lines, get_indent(h.depth) .. get_icon(h.depth) .. h.text)
   end
 
   vim.api.nvim_buf_set_lines(bufnr, 0, #lines, false, lines)


### PR DESCRIPTION
This adds the `indent` config option, which sets the indentation depth per header level in the popup