### PR TITLE
Add option to set popup scrolloff

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Default config:
     number = false,
     relativenumber = false,
     cursorline = true,
+    scrolloff = 0,
   },
   highlight_groups = {
     title = { fg = nil, bg = nil },

--- a/doc/md-headers.txt
+++ b/doc/md-headers.txt
@@ -137,6 +137,7 @@ win_options                                                    (table)
         number = false,
         relativenumber = false,
         cursorline = true,
+        scrolloff = 0,
       }
 <
 

--- a/lua/md-headers/model/config.lua
+++ b/lua/md-headers/model/config.lua
@@ -10,6 +10,7 @@ M.defaults = {
     number = false,
     relativenumber = true,
     cursorline = true,
+    scrolloff = 0,
   },
   highlight_groups = {
     title = {

--- a/lua/md-headers/ui/window.lua
+++ b/lua/md-headers/ui/window.lua
@@ -14,6 +14,7 @@ local function set_window_options(win_id)
   vim.api.nvim_set_option_value("number", opts.number, { win = win_id })
   vim.api.nvim_set_option_value("relativenumber", opts.relativenumber, { win = win_id })
   vim.api.nvim_set_option_value("cursorline", opts.cursorline, { win = win_id })
+  vim.api.nvim_set_option_value("scrolloff", opts.scrolloff, { win = win_id })
 end
 
 local function set_buffer_keymaps(bufnr)


### PR DESCRIPTION
This adds the `win_options.scrolloff` config option, to set the popup window's scrolloff